### PR TITLE
Quit app if (presumably accidentally) run

### DIFF
--- a/VerticalBar/AppDelegate.swift
+++ b/VerticalBar/AppDelegate.swift
@@ -16,9 +16,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Insert code here to initialize your application
+        NSApplication.shared.terminate(self)
     }
-    
 }
 
 


### PR DESCRIPTION
I, at least, have been frustrated when I find I've inadvertently opened one of my instances of VerticalBar and now its (noticeably) in my <kbd>Cmd</kbd>+<kbd>Tab</kbd> menu and (not particularly noticeably) using about 14 MiB of RAM

For my part it seems best to just have it always quit itself if clicked (barring some way to make the dock icon ignore clicks entirely). At least in my testing it takes long enough to open and close as here that it doesn't trigger any of the "app closed immediately" watchdogs

But if anyone DOES want to let it be run, there could be a `defaults` setting or something? (or obvs people can comment out the line in XCode before building, but maybe there should be a README line about it?)
